### PR TITLE
Removing PARSENAME from sys.schemas lookup in DropClass procedure

### DIFF
--- a/Source/tSQLt.DropClass.ssp.sql
+++ b/Source/tSQLt.DropClass.ssp.sql
@@ -56,7 +56,7 @@ BEGIN
              UNION ALL
             SELECT 10000,'DROP SCHEMA ' + QUOTENAME(name) +';'
               FROM sys.schemas
-             WHERE schema_id = SCHEMA_ID(PARSENAME(@ClassName,1))
+             WHERE schema_id = SCHEMA_ID(@ClassName)
          ),
          StatementBlob(xml)AS
          (


### PR DESCRIPTION
Proposed solution to issue [https://github.com/tSQLt-org/tSQLt/issues/5](https://github.com/tSQLt-org/tSQLt/issues/5)