### PR TITLE
Added tSQLt.DropAllClasses.ssp

### DIFF
--- a/Source/BuildOrder.txt
+++ b/Source/BuildOrder.txt
@@ -1,5 +1,6 @@
 tSQLt._Header.sql
 tSQLt.DropClass.ssp.sql
+tSQLt.DropAllClasses.ssp.sql
 tSQLt.Private_Bin2Hex.sfn.sql
 tSQLt.Private_NewTestClassList.tbl.sql
 tSQLt.Private_ResetNewTestClassList.ssp.sql

--- a/Source/Source.ssmssqlproj
+++ b/Source/Source.ssmssqlproj
@@ -139,6 +139,12 @@
           <AssociatedConnUserName />
           <FullPath>tSQLt.CaptureOutputLog.tbl.sql</FullPath>
         </FileNode>
+        <FileNode Name="tSQLt.DropAllClasses.ssp.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>tSQLt.DropAllClasses.ssp.sql</FullPath>
+        </FileNode>
         <FileNode Name="tSQLt.DropClass.ssp.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>

--- a/Source/tSQLt.DropAllClasses.ssp.sql
+++ b/Source/tSQLt.DropAllClasses.ssp.sql
@@ -1,0 +1,31 @@
+IF OBJECT_ID('tSQLt.DropAllClasses') IS NOT NULL DROP PROCEDURE tSQLt.DropAllClasses;
+GO
+---Build+
+CREATE PROCEDURE tSQLt.DropAllClasses
+AS
+BEGIN
+  DECLARE TestClass CURSOR LOCAL FAST_FORWARD
+  FOR
+  SELECT s.name
+    FROM sys.schemas s
+      JOIN sys.extended_properties b
+        ON s.schema_id = b.major_id
+          AND b.class = 3
+          AND b.name = 'tSQLt.TestClass';
+
+  DECLARE @schema sysname;
+  OPEN TestClass;
+
+  WHILE 1 = 1
+  BEGIN
+    FETCH NEXT FROM TestClass INTO @schema;
+    IF @@FETCH_STATUS <> 0
+      BREAK;
+    EXEC tSQLt.DropClass @ClassName = @schema;
+  END;
+
+  CLOSE TestClass;
+  DEALLOCATE TestClass;
+END;
+---Build-
+GO

--- a/Tests/DropAllClassesTests.class.sql
+++ b/Tests/DropAllClassesTests.class.sql
@@ -1,0 +1,31 @@
+EXEC tSQLt.NewTestClass 'DropAllClassesTests';
+GO
+CREATE PROC DropAllClassesTests.[test that all test classes are dropped]
+AS
+BEGIN
+    EXEC tSQLt.NewTestClass 'MyTestClass1';
+    EXEC tSQLt.NewTestClass 'MyTestClass2';
+
+    EXEC tSQLt.ExpectNoException;
+    
+    EXEC tSQLt.DropAllClasses;
+    
+    IF(SCHEMA_ID('MyTestClass1') IS NOT NULL)
+      EXEC tSQLt.Fail 'DropAllClasses did not drop MyTestClass1';
+    IF(SCHEMA_ID('MyTestClass2') IS NOT NULL)
+      EXEC tSQLt.Fail 'DropAllClasses did not drop MyTestClass2';
+END;
+GO
+CREATE PROC DropAllClassesTests.[test that schemas that are not test classes are not dropped]
+AS
+BEGIN
+    EXEC('CREATE SCHEMA MyGenericSchema;');
+
+    EXEC tSQLt.ExpectNoException;
+    
+    EXEC tSQLt.DropAllClasses;
+    
+    IF(SCHEMA_ID('MyGenericSchema') IS NULL)
+      EXEC tSQLt.Fail 'DropAllClasses dropped MyGenericSchema';
+END;
+GO

--- a/Tests/Tests.ssmssqlproj
+++ b/Tests/Tests.ssmssqlproj
@@ -91,6 +91,12 @@
           <AssociatedConnUserName />
           <FullPath>BootStrapTest.sql</FullPath>
         </FileNode>
+        <FileNode Name="DropAllClassesTests.class.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>DropAllClassesTests.class.sql</FullPath>
+        </FileNode>
         <FileNode Name="DropClassTests.class.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>


### PR DESCRIPTION
This procedure runs DropClass on all schemas that are marked with a tSQLt.TestClass extended property. This can be used to easily reset your development environment, especially for those of us who make heavy use of query shortcuts (like RunAll) in lieu of GUI tools.

I've included some tests and added to the buildorder.txt file, but I haven't tested a full project build — not really sure how I would go about doing that anyway.