### PR TITLE
Should Uninstall remove all test classes?

### DIFF
--- a/Source/BuildOrder.txt
+++ b/Source/BuildOrder.txt
@@ -1,5 +1,6 @@
 tSQLt._Header.sql
 tSQLt.DropClass.ssp.sql
+tSQLt.DropAllClasses.ssp.sql
 tSQLt.Private_Bin2Hex.sfn.sql
 tSQLt.Private_NewTestClassList.tbl.sql
 tSQLt.Private_ResetNewTestClassList.ssp.sql

--- a/Source/Source.ssmssqlproj
+++ b/Source/Source.ssmssqlproj
@@ -139,6 +139,12 @@
           <AssociatedConnUserName />
           <FullPath>tSQLt.CaptureOutputLog.tbl.sql</FullPath>
         </FileNode>
+        <FileNode Name="tSQLt.DropAllClasses.ssp.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>tSQLt.DropAllClasses.ssp.sql</FullPath>
+        </FileNode>
         <FileNode Name="tSQLt.DropClass.ssp.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>

--- a/Source/tSQLt.DropAllClasses.ssp.sql
+++ b/Source/tSQLt.DropAllClasses.ssp.sql
@@ -6,12 +6,7 @@ AS
 BEGIN
   DECLARE TestClass CURSOR LOCAL FAST_FORWARD
   FOR
-  SELECT s.name
-    FROM sys.schemas s
-      JOIN sys.extended_properties b
-        ON s.schema_id = b.major_id
-          AND b.class = 3
-          AND b.name = 'tSQLt.TestClass';
+  SELECT Name FROM tSQLt.TestClasses;
 
   DECLARE @schema sysname;
   OPEN TestClass;

--- a/Source/tSQLt.DropAllClasses.ssp.sql
+++ b/Source/tSQLt.DropAllClasses.ssp.sql
@@ -1,0 +1,31 @@
+IF OBJECT_ID('tSQLt.DropAllClasses') IS NOT NULL DROP PROCEDURE tSQLt.DropAllClasses;
+GO
+---Build+
+CREATE PROCEDURE tSQLt.DropAllClasses
+AS
+BEGIN
+  DECLARE TestClass CURSOR LOCAL FAST_FORWARD
+  FOR
+  SELECT s.name
+    FROM sys.schemas s
+      JOIN sys.extended_properties b
+        ON s.schema_id = b.major_id
+          AND b.class = 3
+          AND b.name = 'tSQLt.TestClass';
+
+  DECLARE @schema sysname;
+  OPEN TestClass;
+
+  WHILE 1 = 1
+  BEGIN
+    FETCH NEXT FROM TestClass INTO @schema;
+    IF @@FETCH_STATUS <> 0
+      BREAK;
+    EXEC tSQLt.DropClass @ClassName = @schema;
+  END;
+
+  CLOSE TestClass;
+  DEALLOCATE TestClass;
+END;
+---Build-
+GO

--- a/Source/tSQLt.class.sql
+++ b/Source/tSQLt.class.sql
@@ -541,6 +541,8 @@ GO
 CREATE PROCEDURE tSQLt.Uninstall
 AS
 BEGIN
+  EXEC tSQLt.DropAllClasses;
+
   DROP TYPE tSQLt.Private;
 
   EXEC tSQLt.DropClass 'tSQLt';  

--- a/Tests/DropAllClassesTests.class.sql
+++ b/Tests/DropAllClassesTests.class.sql
@@ -1,0 +1,31 @@
+EXEC tSQLt.NewTestClass 'DropAllClassesTests';
+GO
+CREATE PROC DropAllClassesTests.[test that all test classes are dropped]
+AS
+BEGIN
+    EXEC tSQLt.NewTestClass 'MyTestClass1';
+    EXEC tSQLt.NewTestClass 'MyTestClass2';
+
+    EXEC tSQLt.ExpectNoException;
+    
+    EXEC tSQLt.DropAllClasses;
+    
+    IF(SCHEMA_ID('MyTestClass1') IS NOT NULL)
+      EXEC tSQLt.Fail 'DropAllClasses did not drop MyTestClass1';
+    IF(SCHEMA_ID('MyTestClass2') IS NOT NULL)
+      EXEC tSQLt.Fail 'DropAllClasses did not drop MyTestClass2';
+END;
+GO
+CREATE PROC DropAllClassesTests.[test that schemas that are not test classes are not dropped]
+AS
+BEGIN
+    EXEC('CREATE SCHEMA MyGenericSchema;');
+
+    EXEC tSQLt.ExpectNoException;
+    
+    EXEC tSQLt.DropAllClasses;
+    
+    IF(SCHEMA_ID('MyGenericSchema') IS NULL)
+      EXEC tSQLt.Fail 'DropAllClasses dropped MyGenericSchema';
+END;
+GO

--- a/Tests/DropAllClassesTests.class.sql
+++ b/Tests/DropAllClassesTests.class.sql
@@ -1,52 +1,50 @@
 EXEC tSQLt.NewTestClass 'DropAllClassesTests';
 GO
-CREATE PROC DropAllClassesTests.[SetUp]
+
+CREATE PROC DropAllClassesTests.[test DropClass not called if no test classes exist]
 AS
 BEGIN
     EXEC tSQLt.FakeTable 'tSQLt.TestClasses';
     EXEC tSQLt.SpyProcedure 'tSQLt.DropClass';
-END;
-GO
-CREATE PROC DropAllClassesTests.[test DropClass not called if no test classes exist]
-AS
-BEGIN
+
     EXEC tSQLt.DropAllClasses;
     
     EXEC tSQLt.AssertEmptyTable 'tSQLt.DropClass_SpyProcedureLog';
-
 END;
 GO
 CREATE PROC DropAllClassesTests.[test that one test class results in one call to DropClass]
 AS
 BEGIN
+    EXEC tSQLt.FakeTable 'tSQLt.TestClasses';
+    EXEC tSQLt.SpyProcedure 'tSQLt.DropClass';
     EXEC('INSERT INTO tSQLt.TestClasses (Name)
           VALUES  (''MyTestClass'');');
 
+    SELECT ClassName = Name INTO #expected FROM tSQLt.TestClasses;
+
     EXEC tSQLt.DropAllClasses;
 
-    SELECT TOP 0 * INTO #expected FROM tSQLt.DropClass_SpyProcedureLog;
-    INSERT INTO #expected (ClassName)
-    VALUES  ('MyTestClass');
+    SELECT ClassName INTO #actual FROM tSQLt.DropClass_SpyProcedureLog;
 
-    EXEC tSQLt.AssertEqualsTable '#expected', 'tSQLt.DropClass_SpyProcedureLog';
+    EXEC tSQLt.AssertEqualsTable '#expected', '#actual';
 END;
 GO
 CREATE PROC DropAllClassesTests.[test that multiple test classes are all sent to DropClass]
 AS
 BEGIN
+    EXEC tSQLt.FakeTable 'tSQLt.TestClasses';
+    EXEC tSQLt.SpyProcedure 'tSQLt.DropClass';
     EXEC('INSERT INTO tSQLt.TestClasses (Name)
           VALUES  (''MyTestClass1''),
                   (''MyTestClass2''),
                   (''MyTestClass3'');');
 
+    SELECT ClassName = Name INTO #expected FROM tSQLt.TestClasses;
+
     EXEC tSQLt.DropAllClasses;
 
-    SELECT TOP 0 * INTO #expected FROM tSQLt.DropClass_SpyProcedureLog;
-    INSERT INTO #expected (ClassName)
-    VALUES  ('MyTestClass1'),
-            ('MyTestClass2'),
-            ('MyTestClass3');
+    SELECT ClassName INTO #actual FROM tSQLt.DropClass_SpyProcedureLog;
 
-    EXEC tSQLt.AssertEqualsTable '#expected', 'tSQLt.DropClass_SpyProcedureLog';
+    EXEC tSQLt.AssertEqualsTable '#expected', '#actual';
 END;
 GO

--- a/Tests/Tests.ssmssqlproj
+++ b/Tests/Tests.ssmssqlproj
@@ -91,6 +91,12 @@
           <AssociatedConnUserName />
           <FullPath>BootStrapTest.sql</FullPath>
         </FileNode>
+        <FileNode Name="DropAllClassesTests.class.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>DropAllClassesTests.class.sql</FullPath>
+        </FileNode>
         <FileNode Name="DropClassTests.class.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>

--- a/Tests/tSQLt_test.class.sql
+++ b/Tests/tSQLt_test.class.sql
@@ -1606,6 +1606,28 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE tSQLt_test.[test Uninstall removes test classes]
+AS
+BEGIN
+  EXEC tSQLt.SpyProcedure 'tSQLt.DropAllClasses';
+  DECLARE @call INT;
+  BEGIN TRAN;
+  DECLARE @TranName CHAR(32); EXEC tSQLt.GetNewTranName @TranName OUT;
+  SAVE TRAN @TranName;
+
+  EXEC tSQLt.Uninstall;
+  SET @call = (SELECT 1 FROM tSQLt.DropAllClasses_SpyProcedureLog);
+
+  ROLLBACK TRAN @TranName;
+  COMMIT TRAN;
+  
+  IF @id IS NULL
+  BEGIN
+    EXEC tSQLt.Fail 'DropAllClasses not called';
+  END;
+END;
+GO
+
 CREATE PROCEDURE tSQLt_test.[test Uninstall removes schema tSQLt]
 AS
 BEGIN


### PR DESCRIPTION
I think, since test classes are created and usually destroyed using tSQLt procedures, that the user expectation for running tSQLt.Uninstall is that all of their test classes will be removed as well, since after that point, the DropClass procedure is no longer available.

So, I propose that Uninstall should remove all test classes automatically.

(I haven't verified the last test here works as expected — if this sounds like a good idea to people, I'll double-check and make sure everything works.