### PR TITLE
Fixed issue in tSQLt.Private_GetFullTypeName not handling fractional seconds precision on date and time types

### DIFF
--- a/Source/tSQLt.Private_GetFullTypeName.sfn.sql
+++ b/Source/tSQLt.Private_GetFullTypeName.sfn.sql
@@ -17,6 +17,8 @@ FROM(
                     THEN '(' + CAST(@Length AS NVARCHAR) + ')'
                    WHEN T.name IN ('decimal', 'numeric')
                     THEN '(' + CAST(@Precision AS NVARCHAR) + ',' + CAST(@Scale AS NVARCHAR) + ')'
+                   WHEN T.name IN ('datetime2', 'datetimeoffset', 'time')
+                    THEN '(' + CAST(@Scale AS NVARCHAR) + ')'					
                    ELSE ''
                END Suffix,
               CASE WHEN @CollationName IS NULL OR T.is_user_defined = 1 THEN ''

--- a/Tests/Private_GetFullTypeNameTests.class.sql
+++ b/Tests/Private_GetFullTypeNameTests.class.sql
@@ -90,6 +90,42 @@ BEGIN
 END
 GO
 
+CREATE PROC Private_GetFullTypeNameTests.[test Private_GetFullTypeName should properly return DATETIME2 parameters]
+AS
+BEGIN
+    DECLARE @Result VARCHAR(MAX);
+
+    SELECT @Result = TypeName
+     FROM tSQLt.Private_GetFullTypeName(TYPE_ID('datetime2'), NULL, NULL, 3, NULL);
+
+    EXEC tSQLt.AssertEqualsString '[sys].[datetime2](3)', @Result;
+END
+GO
+
+CREATE PROC Private_GetFullTypeNameTests.[test Private_GetFullTypeName should properly return TIME parameters]
+AS
+BEGIN
+    DECLARE @Result VARCHAR(MAX);
+
+    SELECT @Result = TypeName
+     FROM tSQLt.Private_GetFullTypeName(TYPE_ID('time'), NULL, NULL, 4, NULL);
+
+    EXEC tSQLt.AssertEqualsString '[sys].[time](4)', @Result;
+END
+GO
+
+CREATE PROC Private_GetFullTypeNameTests.[test Private_GetFullTypeName should properly return DATETIMEOFFSET parameters]
+AS
+BEGIN
+    DECLARE @Result VARCHAR(MAX);
+
+    SELECT @Result = TypeName
+     FROM tSQLt.Private_GetFullTypeName(TYPE_ID('datetimeoffset'), NULL, NULL, 6, NULL);
+
+    EXEC tSQLt.AssertEqualsString '[sys].[datetimeoffset](6)', @Result;
+END
+GO
+
 CREATE PROC Private_GetFullTypeNameTests.[test Private_GetFullTypeName should properly return typeName when all parameters are valued]
 AS
 BEGIN


### PR DESCRIPTION
A implementation to fix #15. 

I have not been able to run the entire test suite, because I am not too sure how this should be done. I did however execute the Private_GetFullTypeNameTests test on sql2008R2 database with version 1.0.5873.27393.

[Private_GetFullTypeNameTests.txt](https://github.com/tSQLt-org/tSQLt/files/655473/Private_GetFullTypeNameTests.txt)
