### PR TITLE
SQL Cover help

### DIFF
--- a/Source/BuildOrder.txt
+++ b/Source/BuildOrder.txt
@@ -31,7 +31,10 @@ tSQLt.Private_RenameObjectToUniqueNameUsingObjectId.ssp.sql
 tSQLt.RemoveObject.ssp.sql
 tSQLt.RemoveObjectIfExists.ssp.sql
 tSQLt.Private_CleanTestResult.ssp.sql
+tSQLt.Private_CleanTemporaryObject.ssp.sql
 tSQLt.Private_Init.ssp.sql
+tSQLt.TemporaryObject.tbl.sql
+tSQLt.SaveTemporaryObjectId.ssp.sql
 Run_Methods.sql
 tSQLt.ExpectException.ssp.sql
 tSQLt.ExpectNoException.ssp.sql

--- a/Source/Source.ssmssqlproj
+++ b/Source/Source.ssmssqlproj
@@ -3,7 +3,7 @@
   <Items>
     <LogicalFolder Name="Connections" Type="2" Sorted="true">
       <Items>
-        <ConnectionNode Name="Dev_2005:STORMWIND\martin.isaksen">
+        <ConnectionNode Name="Dev_2005:MacWin7A\meinse00">
           <Created>2015-07-26T21:07:57.2567069-06:00</Created>
           <Type>SQL</Type>
           <Server>Dev_2005</Server>
@@ -15,7 +15,7 @@
           <ConnectionProtocol>NotSpecified</ConnectionProtocol>
           <ApplicationName>Microsoft SQL Server Management Studio - Query</ApplicationName>
         </ConnectionNode>
-        <ConnectionNode Name="Dev_tSQLt:STORMWIND\martin.isaksen">
+        <ConnectionNode Name="Dev_tSQLt:MacWin7A\meinse00">
           <Created>2014-07-30T11:44:05.3611369-06:00</Created>
           <Type>SQL</Type>
           <Server>Dev_tSQLt</Server>
@@ -516,6 +516,12 @@
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
           <AssociatedConnUserName />
           <FullPath>tSQLt.TableToText.ssp.sql</FullPath>
+        </FileNode>
+        <FileNode Name="tSQLt.TemporaryObject.tbl.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
+          <AssociatedConnUserName />
+          <FullPath>tSQLt.TemporaryObject.tbl.sql</FullPath>
         </FileNode>
         <FileNode Name="tSQLt._Header.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>

--- a/Source/Source.ssmssqlproj
+++ b/Source/Source.ssmssqlproj
@@ -3,8 +3,8 @@
   <Items>
     <LogicalFolder Name="Connections" Type="2" Sorted="true">
       <Items>
-        <ConnectionNode Name="Dev_2005:MacWin7A\meinse00">
-          <Created>2015-07-26T23:07:57.2567069-04:00</Created>
+        <ConnectionNode Name="Dev_2005:STORMWIND\martin.isaksen">
+          <Created>2015-07-26T21:07:57.2567069-06:00</Created>
           <Type>SQL</Type>
           <Server>Dev_2005</Server>
           <UserName />
@@ -15,8 +15,8 @@
           <ConnectionProtocol>NotSpecified</ConnectionProtocol>
           <ApplicationName>Microsoft SQL Server Management Studio - Query</ApplicationName>
         </ConnectionNode>
-        <ConnectionNode Name="Dev_tSQLt:MacWin7A\meinse00">
-          <Created>2014-07-30T13:44:05.3611369-04:00</Created>
+        <ConnectionNode Name="Dev_tSQLt:STORMWIND\martin.isaksen">
+          <Created>2014-07-30T11:44:05.3611369-06:00</Created>
           <Type>SQL</Type>
           <Server>Dev_tSQLt</Server>
           <UserName />
@@ -204,6 +204,12 @@
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
           <AssociatedConnUserName />
           <FullPath>tSQLt.Private_Bin2Hex.sfn.sql</FullPath>
+        </FileNode>
+        <FileNode Name="tSQLt.Private_CleanTemporaryObject.ssp.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>tSQLt.Private_CleanTemporaryObject.ssp.sql</FullPath>
         </FileNode>
         <FileNode Name="tSQLt.Private_CleanTestResult.ssp.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
@@ -480,6 +486,12 @@
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
           <AssociatedConnUserName />
           <FullPath>tSQLt.Reset.ssp.sql</FullPath>
+        </FileNode>
+        <FileNode Name="tSQLt.SaveTemporaryObjectId.ssp.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>tSQLt.SaveTemporaryObjectId.ssp.sql</FullPath>
         </FileNode>
         <FileNode Name="tSQLt.SetVerbose.ssp.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>

--- a/Source/tSQLt.Private_CleanTemporaryObject.ssp.sql
+++ b/Source/tSQLt.Private_CleanTemporaryObject.ssp.sql
@@ -1,0 +1,10 @@
+IF OBJECT_ID('tSQLt.Private_CleanTemporaryObject') IS NOT NULL DROP PROCEDURE tSQLt.Private_CleanTemporaryObject;
+GO
+---Build+
+CREATE PROCEDURE tSQLt.Private_CleanTemporaryObject
+AS
+BEGIN
+  DELETE FROM tSQLt.TemporaryObject;
+END
+---Build-
+GO

--- a/Source/tSQLt.Private_Init.ssp.sql
+++ b/Source/tSQLt.Private_Init.ssp.sql
@@ -6,6 +6,7 @@ CREATE PROCEDURE tSQLt.Private_Init
 AS
 BEGIN
   EXEC tSQLt.Private_CleanTestResult;
+  EXEC tSQLt.Private_CleanTemporaryObject;
 
   DECLARE @enable BIT; SET @enable = 1;
   DECLARE @version_match BIT;SET @version_match = 0;

--- a/Source/tSQLt.SaveTemporaryObjectId.ssp.sql
+++ b/Source/tSQLt.SaveTemporaryObjectId.ssp.sql
@@ -1,0 +1,24 @@
+IF OBJECT_ID('tSQLt.SaveTemporaryObjectId') IS NOT NULL DROP PROCEDURE tSQLt.SaveTemporaryObjectId;
+GO
+---Build+
+CREATE PROCEDURE tSQLt.SaveTemporaryObjectId
+  @TempObjectId INT
+  ,@OrgObjectId INT
+AS
+BEGIN
+  IF NOT EXISTS (SELECT * FROM tSQLt.TemporaryObject WHERE TempObjectId = @TempObjectId)
+  BEGIN
+    INSERT INTO tSQLt.TemporaryObject
+    (
+        TempObjectId
+        ,OrgObjectId
+    )
+    VALUES
+    (
+        @TempObjectId
+        ,@OrgObjectId
+    );
+  END
+END
+---Build-
+GO

--- a/Source/tSQLt.TemporaryObject.tbl.sql
+++ b/Source/tSQLt.TemporaryObject.tbl.sql
@@ -1,0 +1,8 @@
+IF OBJECT_ID('tSQLt.TemporaryObject') IS NOT NULL DROP TABLE tSQLt.TemporaryObject;
+---Build+
+CREATE TABLE tSQLt.TemporaryObject
+(
+    TempObjectId INT
+    ,OrgObjectId INT
+);
+---Build-

--- a/Tests/Private_CleanTemporaryObjectTests.class.sql
+++ b/Tests/Private_CleanTemporaryObjectTests.class.sql
@@ -1,0 +1,15 @@
+EXEC tSQLt.NewTestClass 'Private_CleanTemporaryObjectTests';
+GO
+CREATE PROC Private_CleanTemporaryObjectTests.[test all TemporaryObject data is removed]
+AS
+BEGIN
+    EXEC tSQLt.FakeTable @Tablename = N'tSQLt.Private_CleanTemporaryObject';
+
+    INSERT INTO tSQLt.Private_CleanTemporaryObject (TempObjectId, OrgObjectId)
+    VALUES (1,1),(2,2);
+
+    EXEC tSQLt.Private_CleanTemporaryObject;
+
+    EXEC tSQLt.AssertEmptyTable @TableName = N'tSQLt.Private_CleanTemporaryObject';
+END;
+GO

--- a/Tests/SaveTemporaryObjectIdTests.class.sql
+++ b/Tests/SaveTemporaryObjectIdTests.class.sql
@@ -1,0 +1,19 @@
+EXEC tSQLt.NewTestClass 'SaveTemporaryObjectIdTests';
+GO
+CREATE PROC SaveTemporaryObjectIdTests.[test row is inserted if it does not exist]
+AS
+BEGIN
+    EXEC tSQLt.FakeTable @TableName = N'tSQLt.TemporaryObject';
+
+    CREATE TABLE #Expected (TempObjectId INT, OrgObjectId INT);
+    CREATE TABLE #Actual (TempObjectId INT, OrgObjectId INT);
+
+    INSERT INTO #Expected ( TempObjectId ,OrgObjectId )
+    VALUES ( 1, 1);
+
+    EXEC tSQLt.SaveTemporaryObjectId @TempObjectId = 1, @OrgObjectId = 1;
+
+    EXEC tSQLt.AssertEqualsTable @Expected = '#Expected', @Actual = '#Actual';
+
+END;
+GO

--- a/Tests/Tests.ssmssqlproj
+++ b/Tests/Tests.ssmssqlproj
@@ -145,6 +145,12 @@
           <AssociatedConnUserName />
           <FullPath>NewTestClassTests.class.sql</FullPath>
         </FileNode>
+        <FileNode Name="Private_CleanTemporaryObject.class.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
+          <AssociatedConnUserName />
+          <FullPath>Private_CleanTemporaryObject.class.sql</FullPath>
+        </FileNode>
         <FileNode Name="Private_NullCellTableTests.class.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
@@ -210,6 +216,12 @@
           <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
           <AssociatedConnUserName />
           <FullPath>Run_Methods_Tests.class.sql</FullPath>
+        </FileNode>
+        <FileNode Name="SaveTemporaryObjectIdTests.class.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>Dev_tSQLt</AssociatedConnSrvName>
+          <AssociatedConnUserName />
+          <FullPath>SaveTemporaryObjectIdTests.class.sql</FullPath>
         </FileNode>
         <FileNode Name="StubRecordTests.class.sql">
           <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:Dev_tSQLt:True</AssociatedConnectionMoniker>


### PR DESCRIPTION
Added new table and procs to keep track of trigger object ids created during testing. This is to help SQL Cover report on trigger coverage.