### PR TITLE
Fix sysname casing for case-sensitive databases.

### DIFF
--- a/Source/Run_Methods.sql
+++ b/Source/Run_Methods.sql
@@ -449,7 +449,7 @@ CREATE PROCEDURE tSQLt.Private_InputBuffer
   @InputBuffer NVARCHAR(MAX) OUTPUT
 AS
 BEGIN
-  CREATE TABLE #inputbuffer(EventType SYSNAME, Parameters SMALLINT, EventInfo NVARCHAR(MAX));
+  CREATE TABLE #inputbuffer(EventType sysname, Parameters SMALLINT, EventInfo NVARCHAR(MAX));
   INSERT INTO #inputbuffer
   EXEC('DBCC INPUTBUFFER(@@SPID) WITH NO_INFOMSGS;');
   SELECT @InputBuffer = I.EventInfo FROM #inputbuffer AS I;


### PR DESCRIPTION
When using tSQLt on a database with SQL_Latin1_General_CP1_CS_AS collation this change fixed an unresolved reference error.