### PR TITLE
Fix support for Azure SQL Database on non-default collations

### DIFF
--- a/Source/Run_Methods.sql
+++ b/Source/Run_Methods.sql
@@ -375,7 +375,7 @@ BEGIN
    SELECT TC.Name
      FROM tSQLt.TestClasses AS TC
      JOIN tSQLt.Private_NewTestClassList AS PNTCL
-       ON PNTCL.ClassName = TC.Name;
+       ON PNTCL.ClassName = TC.Name COLLATE database_default;
 
   OPEN @TestClassCursor;
 END;

--- a/Source/tSQLt.Private_GetDataTypeOrComputedColumnDefinition.sfn.sql
+++ b/Source/tSQLt.Private_GetDataTypeOrComputedColumnDefinition.sfn.sql
@@ -11,7 +11,7 @@ RETURN SELECT
              AS V(UserTypeId, MaxLength, Precision, Scale, CollationName, ObjectId, ColumnId, ReturnDetails)
        CROSS APPLY tSQLt.Private_GetFullTypeName(V.UserTypeId, V.MaxLength, V.Precision, V.Scale, V.CollationName) AS GFTN
         LEFT JOIN (SELECT 1 AS IsComputedColumn,
-                          ' AS '+ cci.definition + CASE WHEN cci.is_persisted = 1 THEN ' PERSISTED' ELSE '' END AS ComputedColumnDefinition,
+                          ' AS '+ cci.definition + CASE WHEN cci.is_persisted = 1 THEN ' PERSISTED' ELSE '' END COLLATE database_default AS ComputedColumnDefinition,
                           cci.object_id,
                           cci.column_id
                      FROM sys.computed_columns cci

--- a/Source/tSQLt.Private_GetForeignKeyDefinition.sfn.sql
+++ b/Source/tSQLt.Private_GetForeignKeyDefinition.sfn.sql
@@ -45,13 +45,13 @@ AS
 RETURN SELECT 'CONSTRAINT ' + name + ' FOREIGN KEY (' +
               parCols + ') REFERENCES ' + refName + '(' + refCols + ')'+
               CASE WHEN @NoCascade = 1 THEN ''
-                ELSE delete_referential_action_cmd + ' ' + update_referential_action_cmd 
-              END AS cmd,
-              CASE 
+                ELSE delete_referential_action_cmd + ' ' + update_referential_action_cmd
+              END COLLATE database_default AS cmd,
+              CASE
                 WHEN RefTableIsFakedInd = 1
-                  THEN 'CREATE UNIQUE INDEX ' + tSQLt.Private::CreateUniqueObjectName() + ' ON ' + refName + '(' + refCols + ');' 
-                ELSE '' 
-              END CreIdxCmd
+                  THEN 'CREATE UNIQUE INDEX ' + tSQLt.Private::CreateUniqueObjectName() + ' ON ' + refName + '(' + refCols + ');'
+                ELSE ''
+              END COLLATE database_default AS CreIdxCmd
          FROM (SELECT QUOTENAME(SCHEMA_NAME(k.schema_id)) AS SchemaName,
                       QUOTENAME(k.name) AS name,
                       QUOTENAME(OBJECT_NAME(k.parent_object_id)) AS parName,

--- a/Source/tSQLt.Private_ScriptIndex.sfn.sql
+++ b/Source/tSQLt.Private_ScriptIndex.sfn.sql
@@ -42,7 +42,7 @@ RETURN
            THEN 'WITH(STATISTICS_ONLY = -1)'
            ELSE ''
          END +
-         ';' AS create_cmd
+         ';' COLLATE database_default AS create_cmd
     FROM tSQLt.Private_SysIndexes AS I
    CROSS APPLY
    (


### PR DESCRIPTION
This PR fixes support for installing the tSQLt framework on Azure SQL Database when the collation is not the default SQL_Latin1_General_CP1_CI_AS.

The problem is that the sys.* view are always SQL_Latin1_General_CP1_CI_AS on an Azure SQL database, even when the database is a different collation. This results in errors when comparing or concaternating strings where one side came from a sys.* view and the other side came from a table/view in the database. By specifying COLLATE database_default, this keeps the behaviour of on-premise SQL Server, where the sys.* views are the same collation as the database.