### PR TITLE
Fixed build order so that the tSQLt.Private_MarktSQLt_TempObject is c…

### DIFF
--- a/CI/Azure-DevOps/AZ_MainPipeline.yml
+++ b/CI/Azure-DevOps/AZ_MainPipeline.yml
@@ -1,7 +1,8 @@
 #tSQLt CI
 name: tSQLt_CI_$(Date:yyyyMMdd)$(Rev:.r)($(Build.BuildId))
 
-trigger: main
+trigger: 
+- main
 pr: none
 
 schedules:

--- a/CI/Azure-DevOps/AZ_MainPipeline.yml
+++ b/CI/Azure-DevOps/AZ_MainPipeline.yml
@@ -1,8 +1,15 @@
 #tSQLt CI
 name: tSQLt_CI_$(Date:yyyyMMdd)$(Rev:.r)($(Build.BuildId))
 
-trigger: none
+trigger: main
 pr: none
+
+schedules:
+- cron: 0 8 * * *
+  displayName: Daily Build of Main Branch
+  branches:
+    include: main
+  always: true
 
 pool:
   vmImage: 'windows-latest'

--- a/CI/Azure-DevOps/AZ_MainPipeline.yml
+++ b/CI/Azure-DevOps/AZ_MainPipeline.yml
@@ -9,7 +9,8 @@ schedules:
 - cron: 0 8 * * *
   displayName: Daily Build of Main Branch
   branches:
-    include: main
+    include:
+    - main
   always: true
 
 pool:

--- a/Source/BuildOrder.txt
+++ b/Source/BuildOrder.txt
@@ -57,6 +57,7 @@ tSQLt.Private_Seize.tbl.sql
 tSQLt.Private_Init.ssp.sql
 tSQLt.Private_HostPlatform.svw.sql
 tSQLt.Private_NoTransactionTableAction.view.sql
+tSQLt.Private_MarktSQLtTempObject.ssp.sql
 tSQLt.Private_NoTransactionHandleTable.ssp.sql
 tSQLt.Private_NoTransactionHandleTables.ssp.sql
 tSQLt.Private_CleanUpCmdHandler.ssp.sql
@@ -71,7 +72,6 @@ tSQLt.Private_ScriptIndex.sfn.sql
 tSQLt.Private_RemoveSchemaBinding.ssp.sql
 tSQLt.Private_RemoveSchemaBoundReferences.ssp.sql
 tSQLt.Private_GetForeignKeyDefinition.sfn.sql
-tSQLt.Private_MarktSQLtTempObject.ssp.sql
 ApplyConstraint_Methods.sql
 tSQLt.Private_ValidateFakeTableParameters.ssp.sql
 tSQLt.Private_GetDataTypeOrComputedColumnDefinition.sfn.sql


### PR DESCRIPTION
…ompiled before it is needed (and not after); updated AzDO pipeline to run the build every day and also whenever there is a merge to main.