### PR TITLE
Replace delete statements that truncate tables

### DIFF
--- a/Source/tSQLt.Private_CleanTestResult.ssp.sql
+++ b/Source/tSQLt.Private_CleanTestResult.ssp.sql
@@ -5,7 +5,7 @@ GO
 CREATE PROCEDURE tSQLt.Private_CleanTestResult
 AS
 BEGIN
-   DELETE FROM tSQLt.TestResult;
+   TRUNCATE TABLE tSQLt.TestResult;
 END;
 GO
 ---Build-

--- a/Source/tSQLt.Private_ResetNewTestClassList.ssp.sql
+++ b/Source/tSQLt.Private_ResetNewTestClassList.ssp.sql
@@ -6,7 +6,7 @@ CREATE PROCEDURE tSQLt.Private_ResetNewTestClassList
 AS
 BEGIN
   SET NOCOUNT ON;
-  DELETE FROM tSQLt.Private_NewTestClassList;
+  TRUNCATE TABLE tSQLt.Private_NewTestClassList;
 END;
 GO
 ---Build-

--- a/Source/tSQLt.UndoTestDoubles.ssp.sql
+++ b/Source/tSQLt.UndoTestDoubles.ssp.sql
@@ -128,7 +128,11 @@ BEGIN
 
 
   BEGIN TRAN;
-  DELETE FROM tSQLt.Private_RenamedObjectLog OUTPUT Deleted.* INTO #RenamedObjects;
+
+  INSERT INTO #RenamedObjects
+    SELECT * FROM tSQLt.Private_RenamedObjectLog;
+    
+  TRUNCATE TABLE tSQLt.Private_RenamedObjectLog;
 
   WITH MarkedTestDoubles AS
   (


### PR DESCRIPTION
Improves cases in which DELETE is used to remove all of the rows in a table and replaces it with TRUNCATE which improves performance as it does not scan each row individually before deletion. This also resets the identity column where applicable.

In the case where the DELETE statement outputs to a temporary table, the insert takes place before truncation.

Going forward, this would mean that a user executing this would require at least the ALTER permission rather than DELETE.